### PR TITLE
Turbolinks 5 compatibility

### DIFF
--- a/vendor/assets/javascripts/jquery-dynamic-selectable.coffee
+++ b/vendor/assets/javascripts/jquery-dynamic-selectable.coffee
@@ -33,7 +33,6 @@ class DynamicSelectable
 
 
 createDynamicSelectable = -> $('select[data-dynamic-selectable-url][data-dynamic-selectable-target]').dynamicSelectable()
-                             # $('select[data-dynamic-selectable-url][data-dynamic-selectable-target]').dynamicSelectable()
 
 
 $ ->

--- a/vendor/assets/javascripts/jquery-dynamic-selectable.coffee
+++ b/vendor/assets/javascripts/jquery-dynamic-selectable.coffee
@@ -31,5 +31,13 @@ class DynamicSelectable
     if id && id != ''
       @urlTemplate.replace(/:.+_id/, id)
 
+
+createDynamicSelectable = -> $('select[data-dynamic-selectable-url][data-dynamic-selectable-target]').dynamicSelectable()
+                             # $('select[data-dynamic-selectable-url][data-dynamic-selectable-target]').dynamicSelectable()
+
+
 $ ->
-  $('select[data-dynamic-selectable-url][data-dynamic-selectable-target]').dynamicSelectable()
+  if Turbolinks
+    $(document).on 'turbolinks:load', createDynamicSelectable
+  else
+    $(createDynamicSelectable)


### PR DESCRIPTION
### Adds support for Turbolinks 5 (7769f2c)
* Fixes #15
* checks if `Turbolinks` exists. If so, execute function on `'turbolinks:load'`
  * otherwise, execute function on document load

 ### Removes commented-out code from coffeescript (3dde3e1)